### PR TITLE
[bug] Missing requirement "rich"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["p0dalirius"]
 [tool.poetry.dependencies]
 python = "^3.7"
 impacket = "^0.10.0"
+rich = "^13.0.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 impacket
+rich


### PR DESCRIPTION
Hey! 

Thanks again for these awesome tools. I had an error message for a missing requirement when installing it using pipx. 
```
┌──(kali㉿kali)-[~]
└─$ pipx install git+https://github.com/p0dalirius/smbclient-ng --force
  installed package smbclientng 1.2, installed using Python 3.11.8
  These apps are now globally available
    - smbclientng
    - smbng
done! ✨ 🌟 ✨
                                                                                                                                                                                                                                            
┌──(kali㉿kali)-[~]
└─$ smbclientng
Traceback (most recent call last):
  File "/home/kali/.local/bin/smbclientng", line 5, in <module>
    from smbclientng.__main__ import main
  File "/home/kali/.local/pipx/venvs/smbclientng/lib/python3.11/site-packages/smbclientng/__main__.py", line 10, in <module>
    from smbclientng.core.InteractiveShell import InteractiveShell
  File "/home/kali/.local/pipx/venvs/smbclientng/lib/python3.11/site-packages/smbclientng/core/InteractiveShell.py", line 17, in <module>
    from rich.console import Console
ModuleNotFoundError: No module named 'rich'
```

The changes fixed it for me.
Thanks!
 