### PR TITLE
[bug] Missing requirement "charset-normalizer"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = ["p0dalirius"]
 python = "^3.7"
 impacket = "^0.10.0"
 rich = "^13.0.0"
+charset-normalizer = "^3.3.2"
 
 [tool.poetry.dev-dependencies]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 impacket
 rich
+charset-normalizer


### PR DESCRIPTION
Hello ! 

Thanks for this amazing tool! I got another missing module when installing with pipx.
```
[Jun 03, 2024 - 05:19:07 (EDT)] exegol-oscp_lab /workspace # pipx install git+https://github.com/p0dalirius/smbclient-ng --force
⚠  Note: smbng was already on your PATH at /root/.pyenv/versions/3.11.9/bin/smbng
  installed package smbclientng 1.3, installed using Python 3.11.9
  These apps are now globally available
    - smbclientng
    - smbng
done! ✨ 🌟 ✨

[Jun 03, 2024 - 05:19:23 (EDT)] exegol-oscp_lab /workspace # smbclientng 
Traceback (most recent call last):
  File "/root/.local/bin/smbclientng", line 5, in <module>
    from smbclientng.__main__ import main
  File "/root/.local/share/pipx/venvs/smbclientng/lib/python3.11/site-packages/smbclientng/__main__.py", line 10, in <module>
    from smbclientng.core.InteractiveShell import InteractiveShell
  File "/root/.local/share/pipx/venvs/smbclientng/lib/python3.11/site-packages/smbclientng/core/InteractiveShell.py", line 8, in <module>
    import charset_normalizer
ModuleNotFoundError: No module named 'charset_normalizer'
```

Made the changes and it work for me locally!
Hope this help!