### PR TITLE
[bug] Add default to domain variable to fix NoneType exception

### DIFF
--- a/smbclientng/__main__.py
+++ b/smbclientng/__main__.py
@@ -31,7 +31,7 @@ def parseArgs():
 
     authconn = parser.add_argument_group("Authentication & connection")
     authconn.add_argument("--kdcHost", dest="kdcHost", action="store", metavar="FQDN KDC", help="FQDN of KDC for Kerberos.")
-    authconn.add_argument("-d", "--domain", dest="auth_domain", metavar="DOMAIN", action="store", help="(FQDN) domain to authenticate to")
+    authconn.add_argument("-d", "--domain", dest="auth_domain", metavar="DOMAIN", action="store", default='.', help="(FQDN) domain to authenticate to")
     authconn.add_argument("-u", "--user", dest="auth_username", metavar="USER", action="store", help="user to authenticate with")
 
     secret = parser.add_argument_group()


### PR DESCRIPTION
Heyo!

Just a quick fix for a bug when authenticating without providing a domain...

```
               _          _ _            _
 ___ _ __ ___ | |__   ___| (_) ___ _ __ | |_      _ __   __ _
/ __| '_ ` _ \| '_ \ / __| | |/ _ \ '_ \| __|____| '_ \ / _` |
\__ \ | | | | | |_) | (__| | |  __/ | | | ||_____| | | | (_| |
|___/_| |_| |_|_.__/ \___|_|_|\___|_| |_|\__|    |_| |_|\__, |
    by @podalirius_                             v1.3.1  |___/

Traceback (most recent call last):
  File "/home/a/.local/pipx/venvs/smbclientng/lib/python3.11/site-packages/impacket/ntlm.py", line 576, in getNTLMSSPType1
    domain.encode('utf-16le')
    ^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'encode'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/a/.local/bin/smbng", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/a/.local/pipx/venvs/smbclientng/lib/python3.11/site-packages/smbclientng/__main__.py", line 100, in main
    smbSession.init_smb_session()
  File "/home/a/.local/pipx/venvs/smbclientng/lib/python3.11/site-packages/smbclientng/core/SMBSession.py", line 124, in init_smb_session
    self.connected = self.smbClient.login(
                     ^^^^^^^^^^^^^^^^^^^^^
  File "/home/a/.local/pipx/venvs/smbclientng/lib/python3.11/site-packages/impacket/smbconnection.py", line 278, in login
    return self._SMBConnection.login(user, password, domain, lmhash, nthash)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/a/.local/pipx/venvs/smbclientng/lib/python3.11/site-packages/impacket/smb3.py", line 931, in login
    auth = ntlm.getNTLMSSPType1(self._Connection['ClientName'],domain, self._Connection['RequireSigning'])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/a/.local/pipx/venvs/smbclientng/lib/python3.11/site-packages/impacket/ntlm.py", line 578, in getNTLMSSPType1
    domain = domain.decode(encoding)
             ^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'decode'
```

The fix simply adds a default value of `.` to the `domain` arg. This is a valid domain that means the target local host's namespace.

Happy hacking! 🙂 