### PR TITLE
[bugfix] CWD was added twice (in self.mkdir and in self.put_file_recursively

### DIFF
--- a/smbclientng/core/SMBSession.py
+++ b/smbclientng/core/SMBSession.py
@@ -914,7 +914,7 @@ class SMBSession(object):
                     # Create remote directory
                     remote_dir_path = local_dir_path.replace(os.path.sep, ntpath.sep)
                     self.mkdir(
-                        path=ntpath.normpath(self.smb_cwd + ntpath.sep + remote_dir_path + ntpath.sep)
+                        path=ntpath.normpath(remote_dir_path + ntpath.sep)
                     )
 
                     for local_file_path in local_files[local_dir_path]:


### PR DESCRIPTION
…ely)

I figured out why I was having the error STATUS_OBJECT_PATH_NOT_FOUND in #48 , the self.cwd was added twice in path i.e:

If there is a Prog subdir on remote and I try to upload the folder test/ on it this would result in a directory:

Prog/Prog/test

instead of 

Prog/test

Thus the following put failed bc he didn't have the right path. Here is a screenshot that works with this pr.
![image](https://github.com/p0dalirius/smbclient-ng/assets/57132297/7b680d6b-028f-4016-9c4f-dd7ad286c1eb)
