### PR TITLE
[enhancement] Changed symbol in prompt for compatibility

### DIFF
--- a/smbclientng/core/InteractiveShell.py
+++ b/smbclientng/core/InteractiveShell.py
@@ -1146,12 +1146,12 @@ class InteractiveShell(object):
                 if self.config.no_colors:
                     connected_dot = "[v]"
                 else:
-                    connected_dot = "\x1b[1;92m⏺\x1b[0m"
+                    connected_dot = "\x1b[1;92m■\x1b[0m"
             else:
                 if self.config.no_colors:
                     connected_dot = "[x]"
                 else:
-                    connected_dot = "\x1b[1;91m⏺\x1b[0m"
+                    connected_dot = "\x1b[1;91m■\x1b[0m"
             
             # Session ID if 
             session_prompt = ""


### PR DESCRIPTION
Because windows did not like the old one:

![image](https://github.com/user-attachments/assets/1310fb3c-87f7-4da7-923c-6b708d3da56d)
