### PR TITLE
[enhancement] Implemented --timeout for SMB session with better defaults

### DIFF
--- a/smbclientng/__main__.py
+++ b/smbclientng/__main__.py
@@ -31,6 +31,7 @@ def parseArgs():
     parser.add_argument("-S", "--startup-script", metavar="startup_script", required=False, type=str, help="File containing the list of commands to be typed at start of the console.")  
     parser.add_argument("-N", "--not-interactive", dest="not_interactive", required=False, action="store_true", default=False, help="Non interactive mode.")
     parser.add_argument("-L", "--logfile", dest="logfile", metavar="LOGFILE", required=False, default=None, type=str, help="File to write logs to.")
+    parser.add_argument( "--timeout", dest="timeout", metavar="TIMEOUT", required=False, type=float, default=3, help="Timeout in seconds for SMB connections (default: 3)")
 
     group_target = parser.add_argument_group("Target")
     group_target.add_argument("--host", action="store", metavar="HOST", required=True, type=str, help="IP address or hostname of the SMB Server to connect to.")  
@@ -125,7 +126,8 @@ def main():
         sessionsManager.create_new_session(
             credentials=credentials,
             host=options.host,
-            port=options.port
+            port=options.port,
+            timeout=options.timeout,
         )
 
     # Start the main interactive command line

--- a/smbclientng/core/SessionsManager.py
+++ b/smbclientng/core/SessionsManager.py
@@ -38,7 +38,7 @@ class SessionsManager(object):
         self.config = config
         self.logger = logger
 
-    def create_new_session(self, credentials, host, port=445):
+    def create_new_session(self, credentials, host, timeout, port=445):
         """
         Creates a new session with the given session information.
 
@@ -52,6 +52,7 @@ class SessionsManager(object):
         smbSession = SMBSession(
             host=host,
             port=port,
+            timeout=timeout,
             credentials=credentials,
             config=self.config,
             logger=self.logger
@@ -129,6 +130,7 @@ class SessionsManager(object):
         group_target = mode_create.add_argument_group("Target")
         group_target.add_argument("--host", action="store", metavar="HOST", required=True, type=str, help="IP address or hostname of the SMB Server to connect to.")  
         group_target.add_argument("--port", action="store", metavar="PORT", type=int, default=445, help="Port of the SMB Server to connect to. (default: 445)")
+        group_target.add_argument( "--timeout", dest="timeout", metavar="TIMEOUT", required=False, type=float, default=3, help="Timeout in seconds for SMB connections (default: 3)")
         authconn = mode_create.add_argument_group("Authentication & connection")
         authconn.add_argument("--kdcHost", dest="kdcHost", action="store", metavar="FQDN KDC", help="FQDN of KDC for Kerberos.")
         authconn.add_argument("-d", "--domain", dest="auth_domain", metavar="DOMAIN", action="store", default='.', help="(FQDN) domain to authenticate to.")
@@ -195,7 +197,8 @@ class SessionsManager(object):
             self.create_new_session(
                 credentials=credentials,
                 host=options.host,
-                port=options.port
+                port=options.port,
+                timeout=options.timeout
             )
         
         # 

--- a/smbclientng/core/utils.py
+++ b/smbclientng/core/utils.py
@@ -452,26 +452,27 @@ def resolve_remote_files(smbSession, arguments):
     return resolved_pathFromRoot_files
 
 
-def is_port_open(target, port) -> bool:
+def is_port_open(target, port, timeout):
     """
     Check if a specific port on a target host is open.
 
     This function attempts to establish a TCP connection to the specified port on the target host.
     If the connection is successful, it indicates that the port is open. If the connection fails,
-    it indicates that the port is closed or the host is unreachable.
+    it returns the error message.
 
     Args:
         target (str): The hostname or IP address of the target host.
         port (int): The port number to check.
+        timeout (float): The timeout in seconds for the connection attempt. Default is 1.0 second.
 
     Returns:
-        bool: True if the port is open, False otherwise.
+        bool, str: True if the port is open, otherwise False and error message.
     """
-
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.settimeout(0.1)
-        # Non-existant domains cause a lot of errors, added error handling
-        try:
-            return s.connect_ex((target, port)) == 0
-        except Exception as e:
-            return False
+    
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(timeout)
+            s.connect((target, port))
+            return True, None
+    except Exception as e:
+        return False, str(e)


### PR DESCRIPTION
Added `--timeout` option, defaulting to 3 sections, the timeout error will also be returned to help with troubleshooting.

Fixes #101

![2024-09-26_22-46](https://github.com/user-attachments/assets/6276d953-390e-4dd8-a7c3-a27f218ce54b)