### PR TITLE
[bugfix] lbat and lcat used the wrong function to resolve wildcards.

### DIFF
--- a/smbclientng/core/InteractiveShell.py
+++ b/smbclientng/core/InteractiveShell.py
@@ -489,7 +489,7 @@ class InteractiveShell(object):
         # SMB share needed             : No
 
         # Parse wildcards
-        files_and_directories = resolve_remote_files(self.sessionsManager.current_session, arguments)
+        files_and_directories = resolve_local_files(arguments)
 
         for path_to_file in files_and_directories:
             # Read the file
@@ -527,7 +527,7 @@ class InteractiveShell(object):
         # SMB share needed             : No
 
         # Parse wildcards
-        files_and_directories = resolve_remote_files(self.sessionsManager.current_session, arguments)
+        files_and_directories = resolve_local_files(arguments)
 
         for path_to_file in files_and_directories:
             # Read the file 


### PR DESCRIPTION
They used the wrong function to resolve wildcards.