### PR TITLE
[bug] Fix `shares rights` throwing errors if a share cannot be accessed.

### DIFF
--- a/smbclientng/core/SMBSession.py
+++ b/smbclientng/core/SMBSession.py
@@ -1405,7 +1405,13 @@ class SMBSession(object):
 
         # Restore the current share
         current_share = self.smb_share
-        self.set_share(shareName=sharename)
+        current_cwd = self.smb_cwd
+        try:
+            self.set_share(shareName=sharename)
+        except:
+            self.set_share(shareName=current_share)
+            self.smb_cwd = current_cwd
+            return {"readable": False, "writable": False}
 
         access_rights = {"readable": False, "writable": False}
 
@@ -1429,6 +1435,7 @@ class SMBSession(object):
 
         # Restore the current share
         self.set_share(shareName=current_share)
+        self.smb_cwd = current_cwd
 
         return access_rights
 
@@ -1460,9 +1467,9 @@ class SMBSession(object):
                 except SessionError as err:
                     self.smb_share = None
                     self.smb_cwd = ""
-                    self.logger.error("Could not access share '%s': %s" % (shareName, err))
+                    raise Exception("Could not access share '%s': %s" % (shareName, err))
             else:
-                self.logger.error("Could not set share '%s', it does not exist remotely." % shareName)
+                raise Exception("Could not set share '%s', it does not exist remotely." % shareName)
         else:
             self.smb_share = None
             


### PR DESCRIPTION
Now `set_share` throws an exception if it is unsuccessful. Also the current working directory is properly restored after executing the command.

Before:
```
■[\\192.168.56.112\Camera Roll\SomeFolder\]> shares rights
WARNING: Checking WRITE access to shares in offensive tools implies creating a folder and trying to delete it.
| If you have CREATE_CHILD rights but no DELETE_CHILD rights, the folder cannot be deleted and will remain on the target.
| Do you want to continue? [N/y] y
[error] Could not access share 'ADMIN$': SMB SessionError: code: 0xc0000022 - STATUS_ACCESS_DENIED - {Access Denied} A process has requested access to an object but has not been granted those access rights.
[error] Could not access share 'C$': SMB SessionError: code: 0xc0000022 - STATUS_ACCESS_DENIED - {Access Denied} A process has requested access to an object but has not been granted those access rights.
┏━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━┓
┃ Share       ┃ Visibility ┃ Type              ┃ Description   ┃ Rights ┃
┡━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━┩
│ ADMIN$      │ Hidden     │ DISKTREE, SPECIAL │ Remote Admin  │        │
│ C$          │ Hidden     │ DISKTREE, SPECIAL │ Default share │        │
│ Camera Roll │ Visible    │ DISKTREE          │               │ READ   │
│ IPC$        │ Hidden     │ IPC, SPECIAL      │ Remote IPC    │ READ   │
│ Users       │ Visible    │ DISKTREE          │               │ READ   │
└─────────────┴────────────┴───────────────────┴───────────────┴────────┘
■[\\192.168.56.112\]>
```

```
■[\\192.168.56.112\Camera Roll\SomeFolder\]> shares rights
WARNING: Checking WRITE access to shares in offensive tools implies creating a folder and trying to delete it.
| If you have CREATE_CHILD rights but no DELETE_CHILD rights, the folder cannot be deleted and will remain on the target.
| Do you want to continue? [N/y] y
┏━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ Share       ┃ Visibility ┃ Type              ┃ Description   ┃ Rights    ┃
┡━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│ ADMIN$      │ Hidden     │ DISKTREE, SPECIAL │ Remote Admin  │ NO ACCESS │
│ C$          │ Hidden     │ DISKTREE, SPECIAL │ Default share │ NO ACCESS │
│ Camera Roll │ Visible    │ DISKTREE          │               │ READ      │
│ IPC$        │ Hidden     │ IPC, SPECIAL      │ Remote IPC    │ READ      │
│ Users       │ Visible    │ DISKTREE          │               │ READ      │
└─────────────┴────────────┴───────────────────┴───────────────┴───────────┘
■[\\192.168.56.112\Camera Roll\SomeFolder\]> 

```