### PR TITLE
[bug] fix argparse bug blocking -k with --kdcHost or password

### DIFF
--- a/smbclientng/console.py
+++ b/smbclientng/console.py
@@ -80,10 +80,6 @@ def parseArgs():
     if options.aes_key:
         options.kerberos = True
 
-    if options.kerberos and not options.kdcHost:
-        print("[!] Kerberos authentication requires --kdcHost.")
-        sys.exit(1)
-
     if options.hashes and ":" not in options.hashes:
         options.hashes = ":" + options.hashes
 

--- a/smbclientng/console.py
+++ b/smbclientng/console.py
@@ -55,6 +55,8 @@ def parseArgs():
     group_auth = parser.add_argument_group("Authentication & Connection")
     group_auth.add_argument("-d", "--domain", default=".", type=str, help="Authentication domain.")
     group_auth.add_argument("-u", "--user", type=str, help="Username for authentication.")
+    group_auth.add_argument("-k", "--kerberos", action="store_true", help="Use Kerberos authentication.")
+    group_auth.add_argument("--kdcHost", type=str, help="Fully qualified domain name (FQDN) of key distribution center (KDC) for Kerberos.")
 
     # Password & Hashes
     group_secrets = parser.add_argument_group("Secrets")
@@ -63,8 +65,6 @@ def parseArgs():
     group_creds.add_argument("--no-pass", action="store_true", help="Do not prompt for a password.")
     group_creds.add_argument("--hashes", type=str, metavar="[LMHASH:]NTHASH", help="NT/LM hashes.")
     group_creds.add_argument("--aes-key", type=str, metavar="HEXKEY", help="AES key for Kerberos authentication.")
-    group_creds.add_argument("-k", "--kerberos", action="store_true", help="Use Kerberos authentication.")
-    group_creds.add_argument("--kdcHost", type=str, help="Fully qualified domain name (FQDN) of key distribution center (KDC) for Kerberos.")
 
     options = parser.parse_args()
 


### PR DESCRIPTION
### Summary

Fixes a bug in the argument parser where `--kerberos` (`-k`) could not be used with `--kdcHost` or when prompting for a password. This prevented legitimate Kerberos authentication flows—such as using a ticket cache, direct password input, or specifying a KDC—from functioning as intended.

### Changes

- Moved `--kerberos` and `--kdcHost` options from the secrets group to the authentication group.
- Consolidated all Kerberos-related flags under the same argument group to avoid argparse’s mutual exclusion errors.
- Enables expected and now working combinations:
  - `-k` with `--kdcHost`
  - `-k` with password prompt
  - `-k` with `KRB5CCNAME` for ticket cache usage

### Notes

This change restores full compatibility with common Kerberos workflows, especially those used in tools like Impacket and during lab setups requiring flexible authentication methods.

#### Working Example (ccache)
![image](https://github.com/user-attachments/assets/7c6cc216-798a-4a05-abf6-0a8e738b50c8)

#### Working Example (password)
![image](https://github.com/user-attachments/assets/5db41009-86bc-4fce-a25c-b237c4956e26)

---

Fixes [#169](https://github.com/p0dalirius/smbclient-ng/issues/169)