### PR TITLE
[Find module] Fix download path duplication and add advanced filtering (exclude/pipe support)

### DIFF
--- a/smbclientng/modules/Find.py
+++ b/smbclientng/modules/Find.py
@@ -4,9 +4,9 @@
 # Author             : Podalirius (@podalirius_)
 # Date created       : 23 may 2024
 
+import fnmatch
 import ntpath
 import os
-import fnmatch
 
 from smbclientng.types.Module import Module
 from smbclientng.types.ModuleArgumentParser import ModuleArgumentParser
@@ -279,7 +279,7 @@ class Find(Module):
                     # Actions on matches
                     if self.options.download:
                         if not entry.is_directory():
-                            # Fix: Calculate relative path to prevent directory duplication
+                            # Calculate relative path to prevent directory duplication
                             path_to_download = fullpath
                             cwd = self.smbSession.smb_cwd
 


### PR DESCRIPTION
This PR introduces fixes and enhancements to the `find` module.

## Bug Fixes

* **Download Path Duplication:** Fixed an issue where running `find . -download` from a subdirectory (e.g., `dir01`) caused the directory name to be duplicated in the local path (e.g., `dir01/dir01/file.txt`). The module now correctly calculates the relative path based on the current SMB working directory.
* **AttributeError**: Fixed an `AttributeError: 'SharedFile' object has no attribute 'get_name'` by switching to `get_longname()`, ensuring compatibility with the underlying `impacket` objects.

## Enhancements

* **New `--exclude` Argument:** Added support for excluding specific filenames from results (e.g., --exclude "*.dll").
* **Pipe `|` Operator Support:** implemented support for the pipe operator in -name, -iname, and --exclude arguments. This allows specifying multiple patterns in a single command.
  * Example: -name "*.txt|*.log"
  * Example: --exclude "*.exe|*.dll|*.tmp"