### PR TITLE
Fix SessionsManager initialization to prevent AttributeError on current_session_id (#182)

### DIFF
--- a/smbclientng/core/SessionsManager.py
+++ b/smbclientng/core/SessionsManager.py
@@ -35,17 +35,16 @@ class SessionsManager(object):
         sessions (dict): A dictionary of all active sessions, keyed by their session ID.
     """
 
-    sessions = {}
-    next_session_id: int = 1
-    current_session: Optional[SMBSession] = None
-    current_session_id: Optional[int]
-
     config: Config
     logger: Logger
 
     def __init__(self, config: Config, logger: Logger):
         self.config = config
         self.logger = logger
+        self.sessions: dict = {}
+        self.next_session_id: int = 1
+        self.current_session: Optional[SMBSession] = None
+        self.current_session_id: Optional[int] = None
 
     def create_new_session(
         self,


### PR DESCRIPTION
### Linked Issue
Closes #182

### Root Cause
`SessionsManager` declared its session state as class-level attributes. `current_session_id: Optional[int]` was a bare type annotation with no assignment, so the attribute was not created on the class at all; accessing it before a successful session was established raised `AttributeError`. `current_session` was defaulted to `None` by a previous fix, but `current_session_id`, `sessions`, and `next_session_id` were either uninitialized or held as mutable class state shared across instances. The net effect is that running `smbclientng --host <x>` without credentials — or with failed auth — could crash on attribute access when code subsequently touched `current_session_id`.

### Fix Description
Move session state from class-level attributes into `__init__`, giving every instance its own initialized `sessions`, `next_session_id`, `current_session`, and `current_session_id`. `current_session` and `current_session_id` now default to `None`, matching the pre-existing fix for `current_session` and eliminating the same bug class for `current_session_id`. Moving `sessions` into the instance also removes a latent bug where multiple `SessionsManager` instances would share the same session dict.

### How Verified
- Static: before the fix, `SessionsManager(...).current_session_id` raises `AttributeError`; after the fix, it returns `None`.
- Runtime: reproduced the original traceback by removing the pre-existing `current_session = None` class-level default (simulating older shipped builds), ran `smbclientng --host 127.0.0.1 -N -C help` and got the exact `AttributeError: 'SessionsManager' object has no attribute 'current_session'`. After the patch, the same invocation runs cleanly and prints help output.
- Isolation check: instantiated two `SessionsManager` objects and mutated `sm1.sessions`; `sm2.sessions` remains `{}`, confirming per-instance state.

### Test Coverage
**None.** The project has no test harness for the session manager lifecycle and no mocks for SMB dependencies; adding one would require introducing a testing framework. Verified via runtime reproduction and static analysis as described above.

### Scope of Change
- **Files changed:** `smbclientng/core/SessionsManager.py`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local, surgical change. Semantics of a single `SessionsManager` instance are unchanged, since all references go through `self.` and class-level defaults were already `None` or empty. Safe to merge without staged rollout.