### PR TITLE
Fix get command silently swallowing local PermissionError (#172)

### DIFF
--- a/smbclientng/core/LocalFileIO.py
+++ b/smbclientng/core/LocalFileIO.py
@@ -70,12 +70,15 @@ class LocalFileIO(object):
                 "Openning local '%s' with mode '%s'" % (self.path, self.mode)
             )
 
+            local_path = self.dir + os.path.sep + os.path.basename(self.path)
             try:
-                self.fd = open(
-                    self.dir + os.path.sep + os.path.basename(self.path), self.mode
-                )
-            except PermissionError:
+                self.fd = open(local_path, self.mode)
+            except (PermissionError, OSError) as err:
                 self.fd = None
+                self.logger.error(
+                    "Cannot open local file '%s' for writing: %s"
+                    % (local_path, err)
+                )
 
         # Write to remote (read local)
         elif self.mode in ["rb"]:
@@ -88,15 +91,19 @@ class LocalFileIO(object):
 
             try:
                 self.fd = open(self.path, self.mode)
-            except PermissionError:
+            except (PermissionError, OSError) as err:
                 self.fd = None
+                self.logger.error(
+                    "Cannot open local file '%s' for reading: %s"
+                    % (self.path, err)
+                )
 
             if self.fd is not None:
                 if self.expected_size is None:
                     self.expected_size = os.path.getsize(filename=self.path)
 
-        # Create progress bar
-        if self.expected_size is not None:
+        # Create progress bar only if the file descriptor was opened successfully
+        if self.expected_size is not None and self.fd is not None:
             self.__progress = Progress(
                 TextColumn("[bold blue]{task.description}", justify="right"),
                 BarColumn(bar_width=None),
@@ -177,7 +184,7 @@ class LocalFileIO(object):
             except (PermissionError, FileNotFoundError):
                 pass
 
-        if self.expected_size is not None:
+        if self.expected_size is not None and self.fd is not None:
             self.__progress.stop()
 
         del self

--- a/smbclientng/core/SMBSession.py
+++ b/smbclientng/core/SMBSession.py
@@ -498,6 +498,11 @@ class SMBSession(object):
                     expected_size=entry.get_filesize(),
                     keepRemotePath=keepRemotePath,
                 )
+                if f.fd is None:
+                    # The local file could not be opened (already logged by LocalFileIO).
+                    # Skip the remote transfer to avoid discarding data silently.
+                    f.close()
+                    return
                 try:
                     self.smbClient.getFile(
                         shareName=self.smb_share, pathName=full_path, callback=f.write


### PR DESCRIPTION
### Linked Issue
Closes #172

### Root Cause
`LocalFileIO.__init__` caught `PermissionError` when opening the local destination and quietly set `self.fd = None`, with no logging. `write()` then returned `0` for every chunk delivered by `impacket.getFile`, so the remote read continued to completion while all bytes were discarded, and no error surfaced to the user. The same mask was applied on the read side (`mode="rb"`). The progress bar was also started unconditionally, which produced the "stuck at 0%" output observed in the field and gave the impression of a hang. `SMBSession.download_file` also did not check whether the local file had actually been opened before initiating the SMB transfer, so every failed-open path still issued an `SMB getFile` call with a no-op callback.

### Fix Description
- `LocalFileIO.__init__`: replace the silent `except PermissionError` with `except (PermissionError, OSError)` that emits a clear `logger.error` message naming the local path and the OS error, for both `wb` and `rb` modes. `OSError` is included to cover related failures (e.g. `IsADirectoryError`, `FileNotFoundError` when the parent resolution is off, `OSError: [Errno 30] Read-only file system`).
- `LocalFileIO.__init__` / `close`: only create and stop the rich progress bar when the file descriptor was actually opened. This prevents both the misleading 0%-progress UI and the latent `AttributeError` that the earlier logic would have hit in `close()` when `fd` was `None`.
- `SMBSession.download_file`: if `LocalFileIO.fd is None` after construction, close the stub and return immediately instead of streaming the remote file into `/dev/null`.

### How Verified
- Runtime: reproduced the failure by creating a read-only local directory, `chdir`-ing into it, and constructing `LocalFileIO(mode="wb", path="test.txt", ..., expected_size=100)`. Before the fix, no output was produced and `write()` returned 0 silently; after the fix the logger prints `[error] Cannot open local file './/test.txt' for writing: [Errno 13] Permission denied: './/test.txt'`, `write()` still returns 0 (no data lost — the caller should not invoke the transfer), and `close()` completes cleanly without accessing the uninitialised progress attribute.
- Static: re-read `download_file` to confirm that returning after the `f.close()` guard correctly skips the `smbClient.getFile` call for the failed-open case, and that the existing outer `except Exception` still catches other failure modes.

### Test Coverage
**None.** The project has no test harness covering `LocalFileIO` or `SMBSession` file transfer paths, and adding one would require introducing a testing framework and a mock SMB client. Verified by runtime reproduction against a read-only local directory and by static reading of the surrounding call chain.

### Scope of Change
- **Files changed:** `smbclientng/core/LocalFileIO.py`, `smbclientng/core/SMBSession.py`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Changes are local and only affect paths where opening the local file previously failed. The successful-open path is byte-for-byte identical. Safe to merge.