### PR TITLE
Fix cd falling back to direct listing when parent denies enumeration (#186)

### DIFF
--- a/smbclientng/core/SMBSession.py
+++ b/smbclientng/core/SMBSession.py
@@ -1974,9 +1974,35 @@ class SMBSession(object):
             if path in ["", ".", ".."]:
                 self.smb_cwd = ""
             else:
-                if self.path_isdir(pathFromRoot=path.strip(ntpath.sep)):
-                    # Path exists on the remote
+                path_from_root = path.strip(ntpath.sep)
+                if self.path_isdir(pathFromRoot=path_from_root):
+                    # Parent listing confirmed the target is a directory.
+                    self.smb_cwd = ntpath.normpath(path)
+                elif self._is_listable_directory(pathFromRoot=path_from_root):
+                    # Parent listing is not permitted, but the target itself is
+                    # listable (i.e. it exists and is a directory the user can
+                    # access). Fall back to the direct check so users can cd
+                    # into subdirectories whose parent denies listing.
                     self.smb_cwd = ntpath.normpath(path)
                 else:
                     # Path does not exists or is not a directory on the remote
                     self.logger.error("Remote directory '%s' does not exist." % path)
+
+    def _is_listable_directory(self, pathFromRoot: str) -> bool:
+        """
+        Returns True when the given remote path can be enumerated directly
+        (i.e. `listPath(path + \\*)` succeeds), without requiring the parent to
+        be listable. Used as a fallback for `path_isdir` on shares that deny
+        listing the parent of an accessible subdirectory.
+        """
+        path = pathFromRoot.replace("*", "").replace("/", ntpath.sep)
+        path = ntpath.normpath(path).lstrip(ntpath.sep)
+        if not path or path in [".", ".."]:
+            return True
+        try:
+            self.smbClient.listPath(
+                shareName=self.smb_share, path=path + ntpath.sep + "*"
+            )
+            return True
+        except Exception:
+            return False


### PR DESCRIPTION
### Linked Issue
Closes #186

### Root Cause
`SMBSession.set_cwd` validated the target directory via `path_isdir(pathFromRoot=...)`, which enumerates the *parent* directory and filters for an entry matching the target's basename. On a share where the parent denies listing but a child is still accessible (e.g. `Secure$\IT\carl` in the bug report), parent enumeration returns `STATUS_ACCESS_DENIED`; `path_isdir` swallows the exception and returns `False`, so `set_cwd` reports `Remote directory '...' does not exist` even though `impacket-smbclient` — which does not re-validate via the parent — can cd into the same path.

### Fix Description
Keep `path_isdir` as the primary check (still the cheapest and most correct when the parent is listable) and add a fallback that attempts to list the target *directly* via `listPath(path + "\\*")`. If the direct listing succeeds, the target exists and is a directory the user can enumerate, so `set_cwd` accepts it. If both checks fail, the original "does not exist" error is preserved.

The fallback lives in a new private helper `SMBSession._is_listable_directory(pathFromRoot)` to keep the logic out of `set_cwd` and to avoid broadening `path_isdir`, which is used elsewhere (e.g. `get_file`) and relies on the stricter parent-based semantics.

### How Verified
- Static: traced `set_cwd` with `path = "\\Secure$\\IT\\carl"`. With the patched code, `path_isdir` returns `False` (parent `IT` denies listing), the new `_is_listable_directory` issues `listPath("Secure$\\IT\\carl\\*")`, impacket returns the directory's entries (observed in the original issue via `impacket-smbclient`), and `smb_cwd` is set. For a truly missing path, both `listPath` calls fail (object name not found) and the original error message is emitted.
- Runtime sanity: imported the patched module in a venv to confirm no syntax/typing regressions.

### Test Coverage
**None.** The project has no test harness for SMB session behavior and no mock for impacket's `listPath`. The fix is verified by tracing behavior against the reporter's observed scenario, which matches impacket-smbclient's semantics.

### Scope of Change
- **Files changed:** `smbclientng/core/SMBSession.py`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
`path_isdir` is unchanged, so all other callers (`get_file`, etc.) preserve their existing semantics. The only behavioral shift is that `cd <path>` will now succeed in cases where it previously printed a false "does not exist" error. Safe to merge without staged rollout.