### PR TITLE
[bug] Fix folder autocompletion swallowing user input on space-containing entries (#19)

### DIFF
--- a/smbclientng/core/CommandCompleter.py
+++ b/smbclientng/core/CommandCompleter.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import ntpath
 import os
-import shlex
+import re
 from typing import TYPE_CHECKING
 
 from smbclientng.commands import (Command_acls, Command_bat, Command_bhead,
@@ -33,6 +33,18 @@ if TYPE_CHECKING:
     from smbclientng.core.Config import Config
     from smbclientng.core.Logger import Logger
     from smbclientng.core.SMBSession import SMBSession
+
+
+# Characters that must be escaped so readline can still find a common prefix
+# when some candidates contain spaces or quoting-significant characters.
+# Using backslash escaping (rather than wrapping with quotes) keeps the entry
+# name visible to readline's prefix-matching logic, so TAB completion works
+# when the user has only typed part of an entry's name.
+_SHELL_ESCAPE_PATTERN = re.compile(r"([\s\\\"'])")
+
+
+def _shell_escape(value: str) -> str:
+    return _SHELL_ESCAPE_PATTERN.sub(r"\\\1", value)
 
 
 class CommandCompleter(object):
@@ -156,7 +168,7 @@ class CommandCompleter(object):
                                     matching_entries.append(shares[sharename]["name"])
                             # Final matches
                             for m in matching_entries:
-                                self.matches.append(command + " " + shlex.quote(m))
+                                self.matches.append(command + " " + _shell_escape(m))
 
                         # Autocomplete directory
                         if "remote_directory" in self.commands[command]["autocomplete"]:
@@ -186,12 +198,11 @@ class CommandCompleter(object):
                                         )
                             #
                             for m in matching_entries:
+                                escaped = _shell_escape(m)
                                 if m.lower().startswith(
                                     remainder.lower()
-                                ) or shlex.quote(m).lower().startswith(
-                                    remainder.lower()
-                                ):
-                                    self.matches.append(command + " " + shlex.quote(m))
+                                ) or escaped.lower().startswith(remainder.lower()):
+                                    self.matches.append(command + " " + escaped)
 
                         # Autocomplete file
                         if "remote_file" in self.commands[command]["autocomplete"]:
@@ -218,12 +229,11 @@ class CommandCompleter(object):
                                         matching_entries.append(entry.get_longname())
                             #
                             for m in matching_entries:
+                                escaped = _shell_escape(m)
                                 if m.lower().startswith(
                                     remainder.lower()
-                                ) or shlex.quote(m).lower().startswith(
-                                    remainder.lower()
-                                ):
-                                    self.matches.append(command + " " + shlex.quote(m))
+                                ) or escaped.lower().startswith(remainder.lower()):
+                                    self.matches.append(command + " " + escaped)
 
                         # Autocomplete local_directory
                         if "local_directory" in self.commands[command]["autocomplete"]:
@@ -247,12 +257,11 @@ class CommandCompleter(object):
                                         )
                             #
                             for m in matching_entries:
+                                escaped = _shell_escape(m)
                                 if m.lower().startswith(
                                     remainder.lower()
-                                ) or shlex.quote(m).lower().startswith(
-                                    remainder.lower()
-                                ):
-                                    self.matches.append(command + " " + shlex.quote(m))
+                                ) or escaped.lower().startswith(remainder.lower()):
+                                    self.matches.append(command + " " + escaped)
 
                         # Autocomplete local_file
                         if "local_file" in self.commands[command]["autocomplete"]:
@@ -274,12 +283,11 @@ class CommandCompleter(object):
                                         matching_entries.append(entry_path)
                             #
                             for m in matching_entries:
+                                escaped = _shell_escape(m)
                                 if m.lower().startswith(
                                     remainder.lower()
-                                ) or shlex.quote(m).lower().startswith(
-                                    remainder.lower()
-                                ):
-                                    self.matches.append(command + " " + shlex.quote(m))
+                                ) or escaped.lower().startswith(remainder.lower()):
+                                    self.matches.append(command + " " + escaped)
 
                         else:
                             # Generic case for subcommands


### PR DESCRIPTION
### Linked Issue
Closes #19

### Root Cause
`CommandCompleter.complete` built readline completion candidates by wrapping the entry name with `shlex.quote(...)`. When any candidate contained a space or other quoting-significant character, `shlex.quote` wrapped it with single quotes, while candidates with only "safe" characters were returned as-is. For a directory listing containing both `Program Files/` and `ProgramData/`, the returned matches were:

- `"dir 'Program Files/'"`
- `"dir ProgramData/"`

Readline's TAB logic replaces the active word with the longest common prefix of the candidates. The 5th character differs (`'` vs `P`), so the common prefix is `"dir "` — that is what readline inserted, discarding the `"Pr"` the user had typed. The visible symptom in issue #19 is that typing `dir Pr[TAB]` reverts the line to `dir ` instead of completing to the expected entry or narrowing the candidate set.

### Fix Description
Replace every `shlex.quote(...)` call in `complete()` with a local `_shell_escape()` helper that backslash-escapes whitespace, backslashes, and quote characters instead of wrapping the whole value with quotes. With this change, the same two candidates become:

- `"dir Program\\ Files/"`
- `"dir ProgramData/"`

and readline's common prefix is now `"dir Pr"`, preserving the user's input and allowing subsequent characters (`o`, `g`, ...) to narrow down or complete the entry as expected. `shlex.split` still round-trips these escaped values into the original entry names, so `process_line` in `InteractiveShell` continues to parse them correctly.

### How Verified
- Runtime: simulated the buggy and fixed completion flows with the same input set (`Program Files/`, `ProgramData/`, `Private/`) and confirmed the common-prefix computation returns `"dir Pr"` after the fix vs `"dir "` before.
- Round-trip: verified that `shlex.split("dir Program\\ Files/")` yields `['dir', 'Program Files/']`, so downstream command handling sees the original entry name.
- Static: grepped `smbclientng/core/CommandCompleter.py` to confirm no remaining `shlex.quote` occurrences, and dropped the now-unused `shlex` import.

### Test Coverage
**None.** The project has no tests around `CommandCompleter.complete`, and exercising readline tab-expansion deterministically requires pexpect-style harnessing that is out of scope for this fix. Verified by reproducing the prefix computation programmatically.

### Scope of Change
- **Files changed:** `smbclientng/core/CommandCompleter.py`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Pure change to the string formatting of completion candidates. Candidates that contain no whitespace or quote characters are byte-for-byte identical to the previous output. Candidates with spaces are now backslash-escaped instead of single-quoted; `shlex.split` parses both forms identically, so the command dispatch remains unchanged. Safe to merge.