### PR TITLE
[bug] Fix use and module commands raising IndexError on missing arguments (#192)

### DIFF
--- a/smbclientng/commands/module.py
+++ b/smbclientng/commands/module.py
@@ -26,6 +26,12 @@ class Command_module(Command):
         # Active SMB connection needed : No
         # SMB share needed             : No
 
+        if len(arguments) == 0:
+            interactive_shell.logger.error(
+                "Usage: module <name> [module-arguments...]"
+            )
+            return
+
         module_name = arguments[0]
 
         if module_name in interactive_shell.modules.keys():

--- a/smbclientng/commands/use.py
+++ b/smbclientng/commands/use.py
@@ -35,8 +35,10 @@ class Command_use(Command):
         # SMB share needed             : No
 
         self.options = self.processArguments(arguments=arguments)
+        if self.options is None:
+            return
 
-        sharename = arguments[0]
+        sharename = self.options.sharename
 
         # Reload the list of shares
         shares = interactive_shell.sessionsManager.current_session.list_shares()


### PR DESCRIPTION
### Linked Issue
Closes #192

### Root Cause
`Command_use.run` (at `commands/use.py:37-39`) set `self.options = self.processArguments(arguments)` and then immediately executed `sharename = arguments[0]`. When the user invokes `use` with no arguments, argparse's required-positional check triggers, `processArguments` returns `None`, but the very next line still indexes `arguments[0]` on the empty list — raising `IndexError` and bubbling a stack trace into the shell.

`Command_module.run` (at `commands/module.py:29`) has the same problem: it does not use argparse at all (`setupParser` returns `None`) and goes straight to `module_name = arguments[0]`, which raises `IndexError` on an empty `arguments` list.

### Fix Description
- `Command_use.run`: bail out with `return` when `self.options is None` (argparse rejected the input), and read the share name from `self.options.sharename` instead of `arguments[0]`. This also restores the intent of the argparse parser, which was declaring `sharename` as a required positional.
- `Command_module.run`: explicitly check `len(arguments) == 0` and emit a usage line via the logger before returning, keeping the handler short since this command intentionally does not use argparse.

### How Verified
- Runtime: ran `Command_use(...).run(fake_shell, [], "use")` with a fake connected session — before the fix this raised `IndexError: list index out of range`; after the fix it prints the argparse usage error ("the following arguments are required: sharename") and returns cleanly.
- Runtime: ran `Command_module(...).run(fake_shell, [], "module")` — before the fix, `IndexError`; after the fix, the logger emits `Usage: module <name> [module-arguments...]` and the command returns.
- Static: `grep -n 'arguments\[' smbclientng/commands/` now shows no direct indexing into `arguments` without a preceding length guard.

### Test Coverage
**None.** The project has no command-level test harness; verified by runtime reproduction with fake shell/session stubs as described above.

### Scope of Change
- **Files changed:** `smbclientng/commands/use.py`, `smbclientng/commands/module.py`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local changes confined to two small `run` methods. Successful-argument paths are unchanged semantically (`self.options.sharename == arguments[0]` whenever argparse accepts the input). Safe to merge.