### PR TITLE
Fix mount command corrupting argv due to shell=True with list args (#194)

### DIFF
--- a/smbclientng/core/SMBSession.py
+++ b/smbclientng/core/SMBSession.py
@@ -1276,9 +1276,8 @@ class SMBSession(object):
                     "Executing '%s' with arguments: %s" % (executable, args)
                 )
             process = subprocess.Popen(
-                executable=executable,
-                args=args,
-                shell=True,
+                args=[executable, *args],
+                shell=False,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )


### PR DESCRIPTION
### Linked Issue
Closes #194

### Root Cause
`SMBSession.mount` constructs per-platform `executable` and `args` values and then spawns the subprocess with both `executable=executable` and `shell=True` set, passing `args` as a list. Under `shell=True`, Python invokes the shell named by `executable` (or `/bin/sh` when unset) and treats `args[0]` as the command string to run; any additional list entries are forwarded as arguments to the shell itself, which is why `subprocess.Popen(executable="echo", args=["one","two","three"], shell=True)` visibly produces `-c one two three` (the `-c` is injected by `shell=True`). For `mount`, `net use`, and `mount_smbfs`, this meant the tool received an unwanted `-c` flag and the intended argv was collapsed into a single shell-command string — a pattern that does not match any of the three mount tools' accepted invocations.

### Fix Description
Switch to the normal `shell=False` form with an explicit argv list: `args=[executable, *args]`. Each element of the list is delivered unmodified to `execve(2)` — no shell parsing, no implicit `-c`, and no extra quoting needed around the `-o username=...,password=...` option that `credentials.password` feeds into. The `executable` parameter is dropped because it is no longer needed when `args[0]` is the command name.

### How Verified
- Runtime: reproduced the broken behavior before the fix with a harmless binary — `Popen(executable="echo", args=["one","two","three"], shell=True)` printed `-c one two three`. After the fix, `Popen(args=["echo","one","two","three"], shell=False)` prints `one two three`, which is what every `mount` branch intended.
- Static: re-read the Linux / Windows / macOS branches of `SMBSession.mount` to confirm that each constructs `args` as the tool's own argv *without* the executable name, matching the new `[executable, *args]` convention at the call site.

### Test Coverage
**None.** Running the actual mount tools requires root and a real SMB target; there is no existing test harness, and adding one would require substantial CI infrastructure. Verified by direct subprocess reproduction against `echo` as described above.

### Scope of Change
- **Files changed:** `smbclientng/core/SMBSession.py`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
The subprocess call is the only line that changes; the per-platform argv construction is untouched. Because the old invocation never produced a correct mount command, no user flow that previously worked will regress. Safe to merge.