### PR TITLE
[bug] Fix put command failing on absolute local paths due to file-as-directory listdir (#200)

### DIFF
--- a/smbclientng/core/SMBSession.py
+++ b/smbclientng/core/SMBSession.py
@@ -1435,7 +1435,7 @@ class SMBSession(object):
         if os.path.sep in localpath:
             if localpath.startswith(os.path.sep):
                 # Absolute path
-                tmp_search_path = os.path.normpath(localpath)
+                tmp_search_path = os.path.normpath(os.path.dirname(localpath))
             else:
                 # Relative path
                 tmp_search_path = os.path.normpath(


### PR DESCRIPTION
### Linked Issue
Closes #200

### Root Cause
`SMBSession.put_file` builds `tmp_search_path` — the directory it will enumerate for candidate uploads — from `localpath`. The relative-path branch correctly uses `os.path.dirname(localpath)`, but the absolute-path branch at `SMBSession.py:1438` dropped the `dirname` call and used `os.path.normpath(localpath)` directly. For an absolute file path such as `/tmp/foo.txt`, this sets `tmp_search_path` to the *file itself*, and the subsequent `os.listdir(tmp_search_path)` raises `NotADirectoryError: [Errno 20]`, aborting the upload before any SMB work happens.

### Fix Description
Wrap the absolute-path assignment in `os.path.dirname(...)`, mirroring the relative-path branch below it. The rest of the function is unchanged. `put foo.txt` (cwd-relative) and `put -r <dir>` continue to take their existing code paths.

### How Verified
- Runtime: before the fix, `os.listdir(os.path.normpath('/tmp/foo.txt'))` raises `NotADirectoryError: [Errno 20] Not a directory`. After the fix, `os.listdir(os.path.normpath(os.path.dirname('/tmp/foo.txt')))` enumerates `/tmp` as intended, and the existing `if entry == filename` filter selects `foo.txt` for upload.
- Static: both branches of the `if/else` now reduce to the directory containing `localpath`, which is the invariant `os.listdir` requires.

### Test Coverage
**None.** The project has no test harness for `put_file`; the one-line fix is verified by reproducing the failing `os.listdir` call and the now-succeeding `dirname`-based variant.

### Scope of Change
- **Files changed:** `smbclientng/core/SMBSession.py`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Surgical one-line change to an absolute-path-only branch. Relative paths, basenames, and recursive uploads are unchanged. Safe to merge.