### PR TITLE
Fix lcp autocompleting remote files instead of local files (#202)

### DIFF
--- a/smbclientng/commands/lcp.py
+++ b/smbclientng/commands/lcp.py
@@ -18,7 +18,7 @@ class Command_lcp(Command):
     HELP = {
         "description": [description, "Syntax: 'lcp <srcfile> <dstfile>'"],
         "subcommands": [],
-        "autocomplete": ["remote_file"],
+        "autocomplete": ["local_file"],
     }
 
     def setupParser(self) -> CommandArgumentParser:


### PR DESCRIPTION
### Linked Issue
Closes #202

### Root Cause
`Command_lcp` copies files locally via `shutil.copyfile(src, dst)` and never touches the SMB share, but its `HELP["autocomplete"]` declaration at `lcp.py:21` was `["remote_file"]`. `CommandCompleter.complete` honors that declaration and asks the remote share for entries whenever the user hits TAB, so a local-only command was performing network round-trips and inserting remote filenames into the `lcp` prompt.

### Fix Description
Change the autocomplete category to `["local_file"]`, matching every other `l*` command in the package (`lcat`, `lbat`, `lrm`, `lrename`, `ltree` for directories, `lls`, `lcd`, `lmkdir`, `lrmdir`). `CommandCompleter.complete` already implements the `local_file` case against `os.listdir`, so no completer changes are needed.

### How Verified
- Static: diffed `lcp.py` against its sibling local-only commands; `lcp` was the only one declaring `remote_file`. After the fix, `grep "autocomplete" smbclientng/commands/l*.py` shows `lcp` using `local_file` alongside the other local commands.
- `CommandCompleter.complete` (`CommandCompleter.py:257-282`) handles `local_file` by listing the local working directory and matching against the typed prefix; the `lcp` handler's runtime behavior is unchanged.

### Test Coverage
**None.** No existing test harness for completion; verified by comparing against the surrounding sibling commands and reading `CommandCompleter.complete`.

### Scope of Change
- **Files changed:** `smbclientng/commands/lcp.py`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
One-line metadata fix in a single command's `HELP` dict. Safe to merge.