### PR TITLE
Allow cd into non-listable SMB directories

### DIFF
--- a/smbclientng/core/SMBSession.py
+++ b/smbclientng/core/SMBSession.py
@@ -23,7 +23,7 @@ from impacket.nt_errors import STATUS_OBJECT_NAME_COLLISION
 from impacket.smb import SMBFileStreamInformation
 from impacket.smb3structs import (DACL_SECURITY_INFORMATION,
                                   FILE_DIRECTORY_FILE, FILE_NON_DIRECTORY_FILE,
-                                  FILE_OPEN, FILE_READ_ATTRIBUTES,
+                                  FILE_OPEN, FILE_READ_ATTRIBUTES, FILE_TRAVERSE,
                                   GROUP_SECURITY_INFORMATION,
                                   OWNER_SECURITY_INFORMATION, READ_CONTROL,
                                   SMB2_0_INFO_FILE, SMB2_FILE_STREAM_INFO)
@@ -1337,8 +1337,8 @@ class SMBSession(object):
         """
         Checks if the specified path is a directory on the SMB share.
 
-        This method determines if a given path corresponds to a directory on the SMB share. It does this by listing the
-        contents of the path and filtering for entries that match the basename of the path and are marked as directories.
+        This method determines if a given path corresponds to a directory on the SMB share. It first tries to resolve it
+        through a directory listing, then falls back to opening the target path directly as a directory.
 
         Args:
             path (str, optional): The path to check on the SMB share. Defaults to None.
@@ -1371,9 +1371,9 @@ class SMBSession(object):
                         if c.get_longname() == ntpath.basename(path)
                         and c.is_directory()
                     ]
-                    return len(contents) != 0
+                    return len(contents) != 0 or self._can_open_directory(path)
                 except Exception:
-                    return False
+                    return self._can_open_directory(path)
         else:
             return False
 
@@ -1979,33 +1979,35 @@ class SMBSession(object):
             else:
                 path_from_root = path.strip(ntpath.sep)
                 if self.path_isdir(pathFromRoot=path_from_root):
-                    # Parent listing confirmed the target is a directory.
-                    self.smb_cwd = ntpath.normpath(path)
-                elif self._is_listable_directory(pathFromRoot=path_from_root):
-                    # Parent listing is not permitted, but the target itself is
-                    # listable (i.e. it exists and is a directory the user can
-                    # access). Fall back to the direct check so users can cd
-                    # into subdirectories whose parent denies listing.
                     self.smb_cwd = ntpath.normpath(path)
                 else:
                     # Path does not exists or is not a directory on the remote
                     self.logger.error("Remote directory '%s' does not exist." % path)
 
-    def _is_listable_directory(self, pathFromRoot: str) -> bool:
+    def _can_open_directory(self, pathFromRoot: str) -> bool:
         """
-        Returns True when the given remote path can be enumerated directly
-        (i.e. `listPath(path + \\*)` succeeds), without requiring the parent to
-        be listable. Used as a fallback for `path_isdir` on shares that deny
-        listing the parent of an accessible subdirectory.
+        Returns True when the given remote path can be opened as a directory,
+        without requiring the parent or target directory to be listable.
         """
         path = pathFromRoot.replace("*", "").replace("/", ntpath.sep)
         path = ntpath.normpath(path).lstrip(ntpath.sep)
         if not path or path in [".", ".."]:
             return True
+        file_id = None
         try:
-            self.smbClient.listPath(
-                shareName=self.smb_share, path=path + ntpath.sep + "*"
+            file_id = self.smbClient.createFile(
+                treeId=self.smb_tree_id,
+                pathName=path,
+                desiredAccess=FILE_TRAVERSE,
+                creationOption=FILE_DIRECTORY_FILE,
+                creationDisposition=FILE_OPEN,
             )
             return True
         except Exception:
             return False
+        finally:
+            if file_id is not None:
+                try:
+                    self.smbClient.closeFile(self.smb_tree_id, file_id)
+                except Exception:
+                    pass


### PR DESCRIPTION
## Summary

  This fixes a case where `cd` fails on a directory that is actually accessible.

On some SMB shares, a user may not be allowed to list a directory, but may still be allowed to access a known subdirectory inside it. The native `smbclient` handles this case, but `smbclient-ng` was rejecting the path because it was using `listPath()` to check if the directory exists.

Since `listPath()` needs listing permissions, the directory was treated as missing when listing was denied.

This change keeps the current check, but falls back to opening the target path directly as a directory. This allows `cd` to work when the user can access the known path, even without list permissions.

## Testing

  - Tested manually on a share where listing is denied but a known subdirectory is accessible.
 
Previously: 

```
■[\\192.168.56.101\]> shares
┏━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┓
┃ Share    ┃ Visibility ┃ Type              ┃ Description         ┃
┡━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━┩
│ ADMIN$   │ Hidden     │ DISKTREE, SPECIAL │ Remote Admin        │
│ C$       │ Hidden     │ DISKTREE, SPECIAL │ Default share       │
│ IPC$     │ Hidden     │ IPC, SPECIAL      │ Remote IPC          │
│ NETLOGON │ Visible    │ DISKTREE          │ Logon server share  │
│ share    │ Visible    │ DISKTREE          │                     │
│ SYSVOL   │ Visible    │ DISKTREE          │ Logon server share  │
└──────────┴────────────┴───────────────────┴─────────────────────┘
■[\\192.168.56.101\]> use share
■[\\192.168.56.101\share\]> ls
[error] SMB SessionError: code: 0xc0000022 - STATUS_ACCESS_DENIED - {Access Denied} A process has requested access to an object but has not been granted those access rights.
■[\\192.168.56.101\share\]> cd COMPUTER
[error] Remote directory 'COMPUTER' does not exist.
■[\\192.168.56.101\share\]> 
```

Now :

```
■[\\192.168.56.101\]> shares
┏━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┓
┃ Share    ┃ Visibility ┃ Type              ┃ Description         ┃
┡━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━┩
│ ADMIN$   │ Hidden     │ DISKTREE, SPECIAL │ Remote Admin        │
│ C$       │ Hidden     │ DISKTREE, SPECIAL │ Default share       │
│ IPC$     │ Hidden     │ IPC, SPECIAL      │ Remote IPC          │
│ NETLOGON │ Visible    │ DISKTREE          │ Logon server share  │
│ share    │ Visible    │ DISKTREE          │                     │
│ SYSVOL   │ Visible    │ DISKTREE          │ Logon server share  │
└──────────┴────────────┴───────────────────┴─────────────────────┘
■[\\192.168.56.101\]> use share
■[\\192.168.56.101\share\]> ls
[error] SMB SessionError: code: 0xc0000022 - STATUS_ACCESS_DENIED - {Access Denied} A process has requested access to an object but has not been granted those access rights.
■[\\192.168.56.101\share\]> cd COMPUTER
■[\\192.168.56.101\share\COMPUTER\]> ls
d-------     0.00 B  2026-06-30 15:32  .\
d-------     0.00 B  2026-06-30 15:31  ..\
d-------     0.00 B  2026-06-30 17:16  test\
■[\\192.168.56.101\share\COMPUTER\]> 

```
