### PR TITLE
[bugfix] Pass the Hash with a LM:NT hash format

### DIFF
--- a/smbclientng/utils/utils.py
+++ b/smbclientng/utils/utils.py
@@ -61,6 +61,10 @@ def parse_lm_nt_hashes(lm_nt_hashes_string: str) -> tuple[str, str]:
         elif m_lm_hash is not None and m_nt_hash is None:
             lm_hash_value = m_lm_hash
             nt_hash_value = "31d6cfe0d16ae931b73c59d7e0c089c0"
+        else:
+            lm_hash_value = m_lm_hash
+            nt_hash_value = m_nt_hash
+
     return lm_hash_value, nt_hash_value
 
 


### PR DESCRIPTION
Greetings,

This PR aims to fix a bug where a PTH authentication doesn't work when a LM:NT hash is given.

Before:
<img width="1291" height="341" alt="image" src="https://github.com/user-attachments/assets/a9ee1b51-8536-4321-bdcb-078aab6399b8" />

After:
<img width="1294" height="355" alt="image" src="https://github.com/user-attachments/assets/6129030e-5b12-4922-a4a1-56c6587b4cb8" />

Regards.